### PR TITLE
Add educational pages and AdSense placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # 🦄 Coloring App Ponies
-Aplicación web infantil para colorear dibujos vectoriales de ponis de forma interactiva.
+Aplicación web infantil para colorear dibujos vectoriales de ponis de forma interactiva. Incluye secciones educativas y juegos lógicos.
 ## Características
 - Paleta de colores amigable
 - Selección dinámica de SVGs
 - Guardado como PNG con html2canvas
 ## Estructura
-/assets/images/pony1.svg  
-/assets/images/pony2.svg  
-/libs/html2canvas.min.js  
+/assets/images/pony1.svg
+/assets/images/pony2.svg
+/libs/html2canvas.min.js
+/assets/css/styles.css
+/assets/js/script.js
 ## Cómo usar
-- Abre `index.html` en navegador  
-- O publica vía GitHub Pages
+- Abre `index.html` en navegador para empezar a colorear
+- Visita `colores.html`, `juegos-logicos.html` y `categorias.html` para las demás secciones
+- O publica el repositorio mediante GitHub Pages
 ## Licencia
 Uso libre para fines educativos

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3,6 +3,17 @@ body {
     text-align: center;
     background: #fff0f5;
 }
+header nav a {
+    margin: 0 10px;
+    text-decoration: none;
+    color: #333;
+}
+.adsense {
+    margin: 20px auto;
+}
+#share-btn {
+    margin-top: 10px;
+}
 .palette {
     margin: 10px;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -38,3 +38,27 @@ function saveDrawing() {
     });
 }
 document.getElementById('image-selector').dispatchEvent(new Event('change'));
+
+function isMobile() {
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+    navigator.userAgent
+  );
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (isMobile()) {
+    document.querySelectorAll('.adsense').forEach((ad) => ad.remove());
+  }
+  const shareBtn = document.getElementById('share-btn');
+  if (shareBtn) {
+    shareBtn.addEventListener('click', () => {
+      const url = window.location.href;
+      const text = '¡Mira mi pony pintado en Coloreame!';
+      const waUrl = `https://wa.me/?text=${encodeURIComponent(text + ' ' + url)}`;
+      const fbUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}&quote=${encodeURIComponent(text)}&hashtag=%23ColoreameWeb`;
+      window.open(waUrl, '_blank');
+      window.open(fbUrl, '_blank');
+    });
+  }
+});
+

--- a/categorias.html
+++ b/categorias.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Dibujos para colorear por categoría</title>
+  <meta name="description" content="Explora dibujos de animales, naturaleza, cultura peruana y más.">
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>🦄 Coloreame</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="colores.html">Colores</a>
+      <a href="juegos-logicos.html">Juegos lógicos</a>
+      <a href="categorias.html">Categorías</a>
+    </nav>
+  </header>
+
+  <div id="ads-top" class="adsense">
+    <!--
+    <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-slot="1234567890"></script>
+    -->
+  </div>
+
+  <h1>Categorías para colorear</h1>
+  <ul>
+    <li>Animales</li>
+    <li>Naturaleza</li>
+    <li>Cultura peruana</li>
+    <li>Letras</li>
+  </ul>
+
+  <div id="ads-bottom" class="adsense">
+    <!--
+    <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-slot="0987654321"></script>
+    -->
+  </div>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/colores.html
+++ b/colores.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Aprende los colores con dibujos infantiles para pintar</title>
+  <meta name="description" content="Aprende los colores pintando dibujos divertidos desde tu navegador.">
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>🦄 Coloreame</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="colores.html">Colores</a>
+      <a href="juegos-logicos.html">Juegos lógicos</a>
+      <a href="categorias.html">Categorías</a>
+    </nav>
+  </header>
+
+  <div id="ads-top" class="adsense">
+    <!--
+    <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-slot="1234567890"></script>
+    -->
+  </div>
+
+  <h1>Aprende los colores</h1>
+  <p>Elige un dibujo y sigue la paleta guiada para aprender.</p>
+
+  <div id="ads-bottom" class="adsense">
+    <!--
+    <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-slot="0987654321"></script>
+    -->
+  </div>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,11 +2,33 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
-    <title>Colorea tu Pony</title>
-    <link rel="stylesheet" href="styles.css">
+    <title>Colorea ponis gratis en línea – Juega y aprende</title>
+    <meta name="description" content="Diviértete coloreando ponis y aprende los colores en línea. Dibujos SVG para colorear, actividades educativas y juegos infantiles.">
+    <meta property="og:title" content="Coloreame – Colorea ponis en línea">
+    <meta property="og:description" content="Sitio infantil para pintar dibujos SVG y actividades educativas.">
+    <meta property="og:image" content="https://tu-dominio.com/assets/images/preview.png">
+    <meta property="og:url" content="https://tu-dominio.com">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
-    <h1>🦄 Colorea tu Pony</h1>
+    <header>
+        <h1>🦄 Coloreame</h1>
+        <nav>
+            <a href="index.html">Inicio</a>
+            <a href="colores.html">Colores</a>
+            <a href="juegos-logicos.html">Juegos lógicos</a>
+            <a href="categorias.html">Categorías</a>
+        </nav>
+    </header>
+
+    <div id="ads-top" class="adsense">
+        <!--
+        <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+                data-ad-slot="1234567890"></script>
+        -->
+    </div>
+
     <div class="palette">
         <button class="color" style="background: red;" data-color="red"></button>
         <button class="color" style="background: blue;" data-color="blue"></button>
@@ -26,7 +48,17 @@
     <div id="drawing-container" class="drawing"></div>
     <button onclick="clearColors()">Limpiar</button>
     <button onclick="saveDrawing()">Guardar como imagen</button>
+
+    <div id="ads-bottom" class="adsense">
+        <!--
+        <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+                data-ad-slot="0987654321"></script>
+        -->
+    </div>
+
+    <button id="share-btn">Compartir este dibujo</button>
+
     <script src="libs/html2canvas.min.js"></script>
-    <script src="script.js"></script>
+    <script src="assets/js/script.js"></script>
 </body>
 </html>

--- a/juegos-logicos.html
+++ b/juegos-logicos.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Juegos lógicos para niños en línea</title>
+  <meta name="description" content="Sopas de letras, laberintos y actividades para aprender jugando.">
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <h1>🦄 Coloreame</h1>
+    <nav>
+      <a href="index.html">Inicio</a>
+      <a href="colores.html">Colores</a>
+      <a href="juegos-logicos.html">Juegos lógicos</a>
+      <a href="categorias.html">Categorías</a>
+    </nav>
+  </header>
+
+  <div id="ads-top" class="adsense">
+    <!--
+    <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-slot="1234567890"></script>
+    -->
+  </div>
+
+  <h1>Juegos lógicos</h1>
+  <p>Aquí encontrarás laberintos y sopas de letras para imprimir o completar en línea.</p>
+
+  <div id="ads-bottom" class="adsense">
+    <!--
+    <script data-ad-client="ca-pub-xxxxxxxxxxxxxxxx"
+            data-ad-slot="0987654321"></script>
+    -->
+  </div>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move assets into `assets/css` and `assets/js`
- add SEO metadata and AdSense blocks to `index.html`
- add new pages: `colores.html`, `juegos-logicos.html`, `categorias.html`
- implement mobile detection and share button
- update README and styles for new structure

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840776c0be08326aa9281b1a3104ade